### PR TITLE
Fixed deprecated plot methods

### DIFF
--- a/vignettes/dynamiccomplexity.Rmd
+++ b/vignettes/dynamiccomplexity.Rmd
@@ -76,8 +76,8 @@ df_vars <- manyAnalystsESM[,vars]
 # Plot the timeseries with NAs in red
 op <- par(mfrow = c(ceiling(length(vars)/4),4),mar =c(2,2,2,2))
 l_ply(seq_along(vars), function(c){
-  imputeTS::plotNA.distribution(x = as.numeric(df_vars[,c]), 
-                                main=colnames(df_vars)[c], 
+  imputeTS::ggplot_na_distribution(x = as.numeric(df_vars[,c]), 
+                                title=colnames(df_vars)[c], 
                                 xlab = "",ylab = "")
   })
 par(op)
@@ -108,14 +108,14 @@ out.cart  <- mice::complete(imp.cart)
 # Plot the timeseries with NAs in red
 for(c in c("angry"%ci%df_vars,"ruminate"%ci%df_vars)){
   cat("Remove NA\n")
-  imputeTS::plotNA.imputations(x.withNA = as.numeric(df_vars[,c]),
-                               x.withImputations = as.numeric(df_vars[,c]%00%0),
-                               main = paste(colnames(df_vars)[c],"NA removed"), xlab = "", ylab = "")
+  imputeTS::ggplot_na_imputations(x_with_na = as.numeric(df_vars[,c]),
+                               x_with_imputations = as.numeric(df_vars[,c]%00%0),
+                               title = paste(colnames(df_vars)[c],"NA removed"), xlab = "", ylab = "")
 
   cat("Classification And Regression Trees\n")
-  imputeTS::plotNA.imputations(x.withNA = as.numeric(df_vars[,c]),
-                               x.withImputations = as.numeric(out.cart[,c]),
-                               main = paste(colnames(df_vars)[c],"CART"), xlab = "", ylab = "")
+  imputeTS::ggplot_na_imputations(x_with_na = as.numeric(df_vars[,c]),
+                               x_with_imputations = as.numeric(out.cart[,c]),
+                               title = paste(colnames(df_vars)[c],"CART"), xlab = "", ylab = "")
 }
 
 ```

--- a/vignettes/imputemissingsata.Rmd
+++ b/vignettes/imputemissingsata.Rmd
@@ -132,7 +132,7 @@ For example, with uniform discrete numbers and/or scales that are bounded (eg. v
 # Use casnet::as.numeric_discrete() to turn a factor or charcter vector into a named numeric vector.
 ca <- as.numeric_discrete(df_vars$cat_ordered, keepNA = TRUE)
 imputations <- imputeTS::na.kalman(ca, model = "auto.arima")
-imputeTS::plotNA.imputations(x.withNA = ca, x.withTruth = as.numeric_discrete(cat_ordered), x.withImputations = imputations)
+imputeTS::ggplot_na_imputations(x_with_na = ca, x_with_truth = as.numeric_discrete(cat_ordered), x_with_imputations = imputations)
 ```
 
 There is a way to adjust the imputation procedure by transforming the data (thanks to Steffen Moritz, author of `imputeTS`, for suggesting this method). The ordered categorical series was created with bounds `1` and `20`.
@@ -147,8 +147,7 @@ imputations <- imputeTS::na.kalman(ca_t, model = "auto.arima")
 # Plot the result
 # Back-transform the imputed forecasts 
 imputationsBack <- (hi-lo)*exp(imputations)/(1+exp(imputations)) + lo
-
-imputeTS::plotNA.imputations(x.withNA = ca, x.withTruth = as.numeric_discrete(cat_ordered), x.withImputations = imputationsBack)
+imputeTS::ggplot_na_imputations(x_with_na = ca, x_with_truth = as.numeric_discrete(cat_ordered), x_with_imputations = imputationsBack)
 ```
 
 

--- a/vignettes/imputemissingsata.Rmd
+++ b/vignettes/imputemissingsata.Rmd
@@ -223,22 +223,22 @@ print(colnames(df_vars)[c])
 withNA  <- as.numeric_discrete(df_vars[,c], keepNA = TRUE)
 Truth   <- as.numeric_discrete(truth[[c]], keepNA = TRUE)
 
-plotNA.imputations(x.withNA = withNA, 
-                   x.withImputations = out.linear[,c], 
-                   x.withTruth = Truth,
-                   main = "linear interpolation",
+ggplot_na_imputations(x_with_na = withNA, 
+                   x_with_imputations = out.linear[,c], 
+                   x_with_truth = Truth,
+                   title = "linear interpolation",
                    ylab = colnames(df_vars)[c])
   
-plotNA.imputations(x.withNA = withNA, 
-                   x.withImputations = as.numeric_discrete(out.auto[,c]), 
-                   x.withTruth = Truth,
-                   main = paste("auto:",imp.mice$method)[c],
+ggplot_na_imputations(x_with_na = withNA, 
+                   x_with_imputations = as.numeric_discrete(out.auto[,c]), 
+                   x_with_truth = Truth,
+                   title = paste("auto:",imp.mice$method)[c],
                    ylab = colnames(df_vars)[c])
   
-plotNA.imputations(x.withNA = withNA, 
-                     x.withImputations = as.numeric_discrete(out.cart[,c]), 
-                     x.withTruth =Truth,
-                     main="regression trees",
+ggplot_na_imputations(x_with_na = withNA, 
+                     x_with_imputations = as.numeric_discrete(out.cart[,c]), 
+                     x_with_truth =Truth,
+                     title="regression trees",
                      ylab = colnames(df_vars)[c])
 
 }


### PR DESCRIPTION
Vignettes were using "plotNA.function" syntax, while imputeTS currently uses "ggplot_na_function" syntax